### PR TITLE
refactor(matcher/map): disable local `Map` matcher

### DIFF
--- a/lib/solid/matcher.ex
+++ b/lib/solid/matcher.ex
@@ -25,29 +25,32 @@ defimpl Solid.Matcher, for: List do
   end
 end
 
-defimpl Solid.Matcher, for: Map do
-  def match(data, []) do
-    {:ok, data}
-  end
+# The built-in Solid matcher for map is disabled for now, in favour of the local implementation in
+# Yggdrasil, which has some very app specific fallback behaviour.
+#
+# defimpl Solid.Matcher, for: Map do
+#   def match(data, []) do
+#     {:ok, data}
+#   end
 
-  def match(data, ["size"]) do
-    {:ok, Map.get(data, "size", Enum.count(data))}
-  end
+#   def match(data, ["size"]) do
+#     {:ok, Map.get(data, "size", Enum.count(data))}
+#   end
 
-  def match(data, [key | []]) do
-    case Map.fetch(data, key) do
-      {:ok, value} -> {:ok, value}
-      _ -> {:error, :not_found}
-    end
-  end
+#   def match(data, [key | []]) do
+#     case Map.fetch(data, key) do
+#       {:ok, value} -> {:ok, value}
+#       _ -> {:error, :not_found}
+#     end
+#   end
 
-  def match(data, [key | keys]) do
-    case Map.fetch(data, key) do
-      {:ok, value} -> @protocol.match(value, keys)
-      _ -> {:error, :not_found}
-    end
-  end
-end
+#   def match(data, [key | keys]) do
+#     case Map.fetch(data, key) do
+#       {:ok, value} -> @protocol.match(value, keys)
+#       _ -> {:error, :not_found}
+#     end
+#   end
+# end
 
 defimpl Solid.Matcher, for: BitString do
   def match(current, []), do: {:ok, current}


### PR DESCRIPTION
This restores commit 8b896ea22e7d4143bfc199a1e76ab9926511db9e which has been apparently lost in the repo - maybe due to wrong force push or due to repo GC activity.

Do not merge.